### PR TITLE
Add search by name feature, Add filter command, fix searching for thumbs

### DIFF
--- a/cmds/filter.py
+++ b/cmds/filter.py
@@ -1,0 +1,158 @@
+import glob
+import random
+from discord import Message, ChannelType
+
+from util import parser, memory, corpora, cache
+from .search import is_similar, get_line_limit, FINGERS, FINGER_ALIASES
+from .homerow import is_homerow
+from .rank import STATS as LAYOUT_STATS
+
+from typing import Callable
+
+METRIC_NAMES = {
+    'sfb', 'sfs', 'alt', 'red', 'roll', 'oneh', 'inroll', 'outroll', 'rolltal', 'inrolltal'
+}
+REVERSE_METRIC_NAMES = {
+    'alt', 'roll', 'oneh', 'inroll', 'outroll', 'rolltal', 'inrolltal'
+}
+FULL_LAYOUT = set('abcdefghijklmnopqrstuvwxyz')
+
+def exec(message: Message):
+    is_dm = message.channel.type is ChannelType.private
+    kwargs: dict[str, str | bool | list] = parser.get_kwargs(message, str, column=list, homerow=str, sort=str,
+                                                             sfb=str, sfs=str, alt=str, red=str,
+                                                             roll=str, oneh=str, inroll=str, outroll=str,
+                                                             rolltal=str, inrolltal=str,
+                                                             name=str,
+                                                             partial=bool,
+                                                             )
+    column: list[str] = kwargs['column']
+    row: str = kwargs['homerow']
+    filter_name: str = kwargs['name']
+    filter_partial: bool = kwargs['partial']
+    sort_metric: str = kwargs['sort']
+
+    filter_stats: dict[str, str] = {stat: kwargs[stat] for stat in METRIC_NAMES}
+    corpus = corpora.get_corpus(message.author.id)
+    sort_method: Callable[[dict], float] | None = LAYOUT_STATS[sort_metric] if sort_metric in METRIC_NAMES else None
+    res_unordered: list[str] = []
+    res_ordered: dict[str, float] = {}
+
+    sfb = column[0] if len(column) > 0 else ''
+    temp_fingers: list[str] = column[1:]
+    sfb_fingers: set[str] = set()
+    # Add sfb fingers and their aliases to set
+    for finger in FINGERS:
+        if finger.lower() in temp_fingers:
+            sfb_fingers.add(finger)
+    for finger_alias, finger_set in FINGER_ALIASES.items():
+        if finger_alias in temp_fingers:
+            sfb_fingers |= finger_set
+
+    # No positional arguments
+    kwargs.pop('args')
+
+    if all(not arg for arg in kwargs.values()):
+        return '```\n' \
+               'filter [--kwargs]\n' \
+               'Supported options: \n' \
+               '[--column <sfb/column, ...fingers>],\n' \
+               '[--homerow <keys / "sequence">],\n' \
+               '[--sort <metric>],\n' \
+               '[--name <name>]\n' \
+               '[--<metric> {< or >}{num}]\n' \
+               '[--partial]\n' \
+               'metrics: sfb, sfs, alt, red, roll, oneh, inroll, outroll, rolltal, inrolltal\n' \
+               '```'
+
+    for file in glob.glob('layouts/*.json'):
+        ll = memory.parse_file(file)
+
+        # Filter by sfb/column
+        if sfb:
+            # no such key in layout
+            if not all(x in ll.keys for x in sfb):
+                continue
+
+            finger_set = set(ll.keys[x].finger for x in sfb)
+            # not sfb
+            if len(finger_set) != 1:
+                continue
+            # have finger constraints but finger is not in constrained fingers
+            if sfb_fingers and not finger_set.issubset(sfb_fingers):
+                continue
+
+        # Filter by homerow but not homerow
+        if row:
+            keys = sorted(ll.keys.items(), key=lambda k: (k[1].row, k[1].col))
+            homerow = ''.join(k for k, v in keys if v.row == 1)
+            if not is_homerow(row, homerow):
+                continue
+
+        # Filter by name but not similar
+        if filter_name and not is_similar(filter_name, ll.name):
+            continue
+
+        # Loop through the stats
+        filtered = True
+        try:
+            cached_stats: dict[str, float] = cache.get(ll.name, corpus)
+        except OSError:
+            continue
+        for stat_name, stat_str in filter_stats.items():
+            if not stat_str:
+                continue
+            stat_method = LAYOUT_STATS[stat_name]
+            stat_value = stat_method(cached_stats)
+            res, err = compare_with_str(stat_str, stat_value)
+            # Syntax error
+            if err is not None:
+                return str(err)
+            if not res:
+                filtered = False
+                break
+
+        # Stats failed comparison checks
+        if not filtered:
+            continue
+
+        # Partial layout disabled but layout does not contain a-z
+        if not filter_partial and not set(ll.keys).issuperset(FULL_LAYOUT):
+            continue
+
+        if sort_method:
+            res_ordered[ll.name] = sort_method(cached_stats)
+        else:
+            res_unordered.append(ll.name)
+
+    if sort_method:
+        res: list[str] = sorted(res_ordered, key=res_ordered.get, reverse=sort_metric in REVERSE_METRIC_NAMES)
+    else:
+        res = res_unordered
+        random.shuffle(res)
+
+    res_len = get_line_limit(res) if is_dm else 20
+    if res_len < 1:
+        return 'No matches found'
+    all_or_n = 'all' if res_len == len(res) else res_len
+
+    lines = [f'I found {len(res)} matches, here are {all_or_n} of them:', '```']
+    lines.extend(res[:res_len] if sort_method else sorted(res[:res_len], key=str.lower))
+    lines.append('```')
+
+    return '\n'.join(lines)
+
+def compare_with_str(rule: str, value: float) -> tuple[bool, Exception | None]:
+    if not rule.startswith(">") and not rule.startswith("<"):
+        return False, ValueError(f"Error: '{rule}' does not start with greater or less than operator")
+    value2_percent, ok = try_into_float(rule[1:])
+    if not ok:
+        return False, ValueError(f"Error: cannot convert '{rule[1:]}' into a number")
+    return value * 100 > value2_percent if rule.startswith(">") else value * 100 < value2_percent, None
+
+def try_into_float(s: str) -> tuple[float, bool]:
+    try:
+        f = float(s)
+    except ValueError as e:
+        return 0, False
+    return f, True

--- a/cmds/search.py
+++ b/cmds/search.py
@@ -8,15 +8,15 @@ from util import parser, memory
 
 # RESTRICTED = True
 
-FINGERS = ['LI', 'LM', 'LR', 'LP', 'RI', 'RM', 'RR', 'RP', 'LT', 'RT']
+FINGERS = ['LI', 'LM', 'LR', 'LP', 'RI', 'RM', 'RR', 'RP', 'LT', 'RT', 'TB']
 FINGER_ALIASES = {
-    'index': {'LI', 'RI'},
+    'index':  {'LI', 'RI'},
     'middle': {'LM', 'RM'},
-    'ring': {'LR', 'RR'},
-    'pinky': {'LP', 'RP'},
-    'thumb': {'LT', "RT'"},
-    'lh': {'LI', 'LM', 'LR', 'LP'},
-    'rh': {'RI', 'RM', 'RR', 'RP'},
+    'ring':   {'LR', 'RR'},
+    'pinky':  {'LP', 'RP'},
+    'thumb':  {'LT', 'RT', 'TB'},
+    'lh': {'LI', 'LM', 'LR', 'LP', 'LT'},
+    'rh': {'RI', 'RM', 'RR', 'RP', 'RT', 'TB'},
 }
 SIMILARITY_THRES = 0.7
 
@@ -24,7 +24,7 @@ def exec(message: Message):
     is_dm = message.channel.type is ChannelType.private
     kwargs: dict[str, str | bool] = parser.get_kwargs(message, str,
                                                       li=bool, lm=bool, lr=bool, lp=bool, lt=bool,
-                                                      ri=bool, rm=bool, rr=bool, rp=bool, rt=bool,
+                                                      ri=bool, rm=bool, rr=bool, rp=bool, rt=bool, tb=bool,
                                                       index=bool, middle=bool, ring=bool, pinky=bool, thumb=bool,
                                                       lh=bool, rh=bool,
                                                       name=list,
@@ -36,7 +36,7 @@ def exec(message: Message):
         return '```\n' \
                'search [sfb/column] [--fingers]\n' \
                'Supported fingers: \n' \
-               'li, lm, lr, lp, ri, rm, rr, rp, lt, rt, index, middle, ring, pinky, thumb, lh, rh, name\n' \
+               'li, lm, lr, lp, ri, rm, rr, rp, lt, rt, tb, index, middle, ring, pinky, thumb, lh, rh, name\n' \
                '```'
     # Only filter by name
     if not sfb:

--- a/cmds/search.py
+++ b/cmds/search.py
@@ -1,6 +1,7 @@
 import json
 import glob
 import random
+from jellyfish import jaro_winkler_similarity as jw
 from discord import Message, ChannelType
 
 from util import parser, memory
@@ -17,22 +18,34 @@ FINGER_ALIASES = {
     'lh': {'LI', 'LM', 'LR', 'LP'},
     'rh': {'RI', 'RM', 'RR', 'RP'},
 }
+SIMILARITY_THRES = 0.7
 
 def exec(message: Message):
+    is_dm = message.channel.type is ChannelType.private
     kwargs: dict[str, str | bool] = parser.get_kwargs(message, str,
                                                       li=bool, lm=bool, lr=bool, lp=bool, lt=bool,
                                                       ri=bool, rm=bool, rr=bool, rp=bool, rt=bool,
                                                       index=bool, middle=bool, ring=bool, pinky=bool, thumb=bool,
-                                                      lh=bool, rh=bool
+                                                      lh=bool, rh=bool,
+                                                      name=list,
                                                       )
-
+    filter_name: str = "".join(kwargs['name'])
     sfb: str = kwargs['args']
-    if not sfb:
+    # No arguments
+    if not sfb and not filter_name:
         return '```\n' \
                'search [sfb/column] [--fingers]\n' \
                'Supported fingers: \n' \
-               'li, lm, lr, lp, ri, rm, rr, rp, lt, rt, index, middle, ring, pinky, thumb, lh, rh\n' \
+               'li, lm, lr, lp, ri, rm, rr, rp, lt, rt, index, middle, ring, pinky, thumb, lh, rh, name\n' \
                '```'
+    # Only filter by name
+    if not sfb:
+        res: list[str] = []
+        for file in glob.glob('layouts/*.json'):
+            name = memory.parse_file(file).name
+            if is_similar(filter_name, name):
+                res.append(name)
+        return return_message(res, is_dm)
 
     # Add fingers to the set
     sfb_fingers: set[str] = {finger for finger in FINGERS if kwargs[finger.lower()]}
@@ -51,44 +64,49 @@ def exec(message: Message):
 
         fingers = set(ll.keys[x].finger for x in sfb)
 
-        if len(fingers) == 1:
-            # any finger or in constrained fingers
-            if not sfb_fingers or fingers.issubset(sfb_fingers):
-                res.append(ll.name)
+        # not sfb
+        if len(fingers) != 1:
+            continue
+        # have finger constraints but finger is not in constrained fingers
+        if sfb_fingers and not fingers.issubset(sfb_fingers):
+            continue
+        # have name filter but name is not similar enough
+        if filter_name and not is_similar(filter_name, ll.name):
+            continue
+        res.append(ll.name)
 
+    return return_message(res, is_dm)
+
+def get_line_limit(res: list[str]) -> int:
+    # Find the max number of lines that fit in the message (only for DMs)
+    char_count = 0
+    line_limit = 0
+    for line in res:
+        char_count += len(line) + 1
+        if char_count > 1900:
+            break
+        line_limit += 1
+    return line_limit
+
+def return_message(res: list[str], is_dm: bool) -> str:
     random.shuffle(res)
-
-    res_len = min(len(res), 20)
+    res_len = get_line_limit(res) if is_dm else 20
     if res_len < 1:
         return 'No matches found'
-
-    is_dm = message.channel.type is ChannelType.private
-
-    # Find the max number of lines that fit in the message (only for DMs)
-    if is_dm:
-        char_count = 0
-        line_limit = 0
-        for line in res:
-            char_count += len(line) + 1
-            if char_count > 1900:
-                break
-            line_limit += 1
-        # set the new result length to the line limit
-        res_len = line_limit
-
     all_or_n = 'all' if res_len == len(res) else res_len
 
-    lines = [f'I found {len(res)} matches, here are {all_or_n} of them:']
-
-    lines.append('```')
+    lines = [f'I found {len(res)} matches, here are {all_or_n} of them:', '```']
     lines += list(sorted(res[:res_len], key=str.lower))
     lines.append('```')
 
     return '\n'.join(lines)
 
+def is_similar(s1: str, s2: str) -> bool:
+    return jw(s1, s2) > SIMILARITY_THRES
+
 
 def use():
-    return 'search [sfb/column] [--fingers]'
+    return 'search [sfb/column] [--fingers | --name]'
 
 
 def desc():

--- a/util/parser.py
+++ b/util/parser.py
@@ -29,76 +29,60 @@ def get_kwargs(message: Message,
     """
     - message: user's message list[str]
     - arg type: str or list[str]
-    - kwargs: arguments with `--` prefix (or '—', '––')
+    - kwargs: arguments with `--` prefix (or `—`, `––`)
+    - kwargs type: bool or list (of str)
     - example:
-        `get_kwargs(Message, min=bool, max=bool)`
-    - return:
-        `dict {'args': str or list[str], 'kwarg1': Any, 'kwarg2': ...}`
+        ```
+        # message.content == "this is args --flag this is ignored --text this is kwargs"
+        kwargs = get_kwargs(message, str, flag=bool, text=list)
+        assert kwargs == {"args": "this is args", "flag": True, "text": ["this", "is", "kwargs"]}
+        ```
+    - reserved names (CANNOT be kwarg names): `message`, `arg_type`, `args`
     """
     message_as_list = message.content.split()
     command: list[str] = message_as_list[2:] if message_as_list[0] in TRIGGERS else message_as_list[1:]
-
     if not command:
-        if arg_type == list[str]:
-            return {'args': ['']}
-        else:
-            return {'args': ''}
+        return {'args': ['']} if arg_type == list else {'args': ''}
 
-    if 'args' in cmd_kwargs:
-        cmd_kwargs.pop('args')  # reserved, no 'args' in kwargs
-
-    args: str | list[str] = ''
-    if starts_with_kw_prefix(command[0]):
-        args = command[0]
-        command.pop(0)
-
-    # ensure all positional
-    kwargs_start_index = 0
-    for i, word in enumerate(command):
-        if starts_with_kw_prefix(word) and remove_kw_prefix(word).lower() in cmd_kwargs:
-            kwargs_start_index = i
+    words: list[str] = command
+    arg_index = 0
+    for word in words:
+        if is_kwarg(cmd_kwargs, word):
             break
-        args += ' ' + word
-    args = args.strip()
-    if arg_type == list[str]:
-        args = args.split()
+        arg_index += 1
 
     # make default dict
-    parsed_kwargs = {'args': args}
+    parsed_kwargs: dict[str, str | bool | list[str]] = {'args': ''}
     for kw_name, kw_type in cmd_kwargs.items():
-        if kw_type == bool:
-            default = False
-        elif kw_type == list:
-            default = []
-        else:
-            default = None
-        parsed_kwargs[kw_name] = default
+        parsed_kwargs[kw_name] = False if kw_type == bool else []
 
-    # handle keyword
-    temp_list = []
-    prev_word = ''
+    args = words[:arg_index]
+    parsed_kwargs['args'] = ' '.join(args) if arg_type == str else args
+
+    words = words[arg_index:]
+    last_in_list = 0
+    last_list_kwarg = ''
     in_list = False
-    for word in command[kwargs_start_index:]:
-        word = remove_kw_prefix(word).lower()
+    for index, word in enumerate(words):
+        if is_kwarg(cmd_kwargs, word):
+            word = remove_kw_prefix(word.lower())
+            kw_type = cmd_kwargs[word]
 
-        if word not in cmd_kwargs:
+            # Encountered next keyword, stops previous list
             if in_list:
-                temp_list.append(word)
-            continue
+                parsed_kwargs[last_list_kwarg] = words[last_in_list:index]
 
-        kw_type = cmd_kwargs.get(word, None)
-        if in_list and kw_type is not None:  # encountered next keyword
-            parsed_kwargs[prev_word] = temp_list.copy()
-            temp_list.clear()
-            in_list = False
-        if kw_type == bool:
-            parsed_kwargs[word] = True
-        if kw_type == list:
-            in_list = True
-            prev_word = word
+            in_list = kw_type == list
+            parsed_kwargs[word] = [] if in_list else True
 
+            # Starts a new list after kwarg
+            if in_list:
+                last_list_kwarg = word
+                last_in_list = index + 1
+
+    # Close the last list
     if in_list:
-        parsed_kwargs[prev_word] = temp_list
+        parsed_kwargs[last_list_kwarg] = words[last_in_list:]
 
     return parsed_kwargs
 
@@ -110,3 +94,9 @@ def remove_kw_prefix(word: str) -> str:
     for prefix in ('--', '—', '––'):
         word = word.removeprefix(prefix)
     return word
+
+def is_kwarg(kwargs: dict[str, Type[bool | list]], word: str) -> bool:
+    if not starts_with_kw_prefix(word):
+        return False
+    word = remove_kw_prefix(word)
+    return word.lower() in kwargs

--- a/util/parser.py
+++ b/util/parser.py
@@ -52,12 +52,10 @@ def get_kwargs(message: Message,
         arg_index += 1
 
     # make default dict
-    parsed_kwargs: dict[str, str | bool | list[str]] = {'args': ''}
+    args = words[:arg_index]
+    parsed_kwargs: dict[str, str | bool | list[str]] = {'args': ' '.join(args) if arg_type == str else args}
     for kw_name, kw_type in cmd_kwargs.items():
         parsed_kwargs[kw_name] = False if kw_type == bool else []
-
-    args = words[:arg_index]
-    parsed_kwargs['args'] = ' '.join(args) if arg_type == str else args
 
     words = words[arg_index:]
     last_in_list = 0
@@ -65,7 +63,7 @@ def get_kwargs(message: Message,
     in_list = False
     for index, word in enumerate(words):
         if is_kwarg(cmd_kwargs, word):
-            word = remove_kw_prefix(word.lower())
+            word = remove_kw_prefix(word)
             kw_type = cmd_kwargs[word]
 
             # Encountered next keyword, stops previous list
@@ -93,10 +91,10 @@ def starts_with_kw_prefix(word: str) -> bool:
 def remove_kw_prefix(word: str) -> str:
     for prefix in ('--', '—', '––'):
         word = word.removeprefix(prefix)
-    return word
+    return word.lower()
 
 def is_kwarg(kwargs: dict[str, Type[bool | list]], word: str) -> bool:
     if not starts_with_kw_prefix(word):
         return False
     word = remove_kw_prefix(word)
-    return word.lower() in kwargs
+    return word in kwargs

--- a/util/parser.py
+++ b/util/parser.py
@@ -42,7 +42,7 @@ def get_kwargs(message: Message,
     message_as_list = message.content.split()
     command: list[str] = message_as_list[2:] if message_as_list[0] in TRIGGERS else message_as_list[1:]
     if not command:
-        return {'args': ['']} if arg_type == list else {'args': ''}
+        return {'args': ''} if arg_type == str else {'args': ['']}
 
     words: list[str] = command
     arg_index = 0


### PR DESCRIPTION
- command: `!cmini search [column] --name [name]`

![Screenshot (61)](https://github.com/Apsu/cmini/assets/96000090/35d93a68-a177-4ad4-bb74-057f8b4cd6ee)
_example of searching by column then filter the results by name_ 

![Screenshot (60)](https://github.com/Apsu/cmini/assets/96000090/1860c403-1954-4787-bd72-a60eb52e78e7)
_example of only searching by name_

- fix cases like `cmd --kwarg` where `--kwarg` is considered part of `args` (--kwargs happens to be a valid `cmd_kwarg`)
  - now returns `args` == "" instead of including the first kwarg
- refactored code to make it more concise