### PR TITLE
Strictly parse kwargs

### DIFF
--- a/cmds/mod.py
+++ b/cmds/mod.py
@@ -7,25 +7,15 @@ from core.keyboard import Layout
 RESTRICTED = False
 
 def exec(message: Message):
-    kwargs = parser.get_kwargs(message, str, angle=bool, unangle=bool, mirror=bool, cycle=list, swap=list)
+    kwargs, err = parser.get_kwargs(message, str, angle=bool, unangle=bool, mirror=bool, cycle=list, swap=list)
+    if err is not None:
+        return (f'{str(err)}\n'
+                f'```\n'
+                f'{use()}\n'
+                f'```')
     layout_name = kwargs['args']
     if not layout_name:
-        kw_tips = """
-                Usage: `mod layout_name [--kwarg1, --kwarg2, ...]`
-                ```
-                --angle:
-                    view the angle modded version of a layout
-                --unangle:
-                    view the non angle modded version of a layout
-                --mirror:
-                    view the mirrored version of a layout
-                --cycle:
-                    cycle a layout's letters around
-                --swap:
-                    alias of --cycle
-                ```
-                """
-        return kw_tips.replace(' ' * 16, '').strip()
+        return f'```\n{use()}\n```'
 
     ll = memory.find(layout_name.lower())
     
@@ -51,7 +41,19 @@ def exec(message: Message):
     return layout.to_string(ll, id=message.author.id)
 
 def use():
-    return 'mod [name] [--kwargs]'
+    return """
+mod layout_name [--kwarg1, --kwarg2, ...]
+--angle:
+    view the angle modded version of a layout
+--unangle:
+    view the non angle modded version of a layout
+--mirror:
+    view the mirrored version of a layout
+--cycle:
+    cycle a layout's letters around
+--swap:
+    alias of --cycle
+"""
 
 def desc():
     return 'see the stats of a layout with chained modifications'
@@ -63,5 +65,3 @@ def __modify_layout(ll: Layout, mode: str, *args):
 def __get_layout_desc(mode: str) -> str:
     mod = import_module(f'cmds.{mode}')
     return mod.desc()
-
-

--- a/cmds/rank.py
+++ b/cmds/rank.py
@@ -63,14 +63,17 @@ def exec(message: Message):
 
     length = 15
 
-    kwargs = parser.get_kwargs(message, list[str], min=bool, max=bool)
+    kwargs, err = parser.get_kwargs(message, list[str], min=bool, max=bool)
+    if err is not None:
+        return (f'{str(err)}\n'
+                f'```\n'
+                f'{use()}\n'
+                f'```')
+
     args = kwargs['args']
     stat = args[0] if len(args) > 0 else ''
     if stat == '':
-        return '```\n' + \
-            'Supported rank stats:\n' + \
-            'alt sfb sfs red oneh inroll outroll roll inrollratio outrollratio inrolltal outrolltal rolltal' + \
-            '```'
+        return f'```\n{use()}\n```'
 
     start = args[1] if len(args) > 1 else 0
     sort_asc = kwargs['min']
@@ -121,7 +124,9 @@ def exec(message: Message):
         ) + '```'
 
 def use():
-    return 'rank [metric]'
+    return ('rank [metric]\n'
+            'Supported rank stats:\n'
+            'alt sfb sfs red oneh inroll outroll roll inrollratio outrollratio inrolltal outrolltal rolltal')
 
 def desc():
     return 'rank layouts based on a metric'

--- a/cmds/search.py
+++ b/cmds/search.py
@@ -1,4 +1,3 @@
-import json
 import glob
 import random
 from jellyfish import jaro_winkler_similarity as jw
@@ -10,34 +9,39 @@ from util import parser, memory
 
 FINGERS = ['LI', 'LM', 'LR', 'LP', 'RI', 'RM', 'RR', 'RP', 'LT', 'RT', 'TB']
 FINGER_ALIASES = {
-    'index':  {'LI', 'RI'},
+    'index': {'LI', 'RI'},
     'middle': {'LM', 'RM'},
-    'ring':   {'LR', 'RR'},
-    'pinky':  {'LP', 'RP'},
-    'thumb':  {'LT', 'RT', 'TB'},
+    'ring': {'LR', 'RR'},
+    'pinky': {'LP', 'RP'},
+    'thumb': {'LT', 'RT', 'TB'},
     'lh': {'LI', 'LM', 'LR', 'LP', 'LT'},
     'rh': {'RI', 'RM', 'RR', 'RP', 'RT', 'TB'},
 }
 SIMILARITY_THRES = 0.7
 
+
 def exec(message: Message):
     is_dm = message.channel.type is ChannelType.private
-    kwargs: dict[str, str | bool] = parser.get_kwargs(message, str,
-                                                      li=bool, lm=bool, lr=bool, lp=bool, lt=bool,
-                                                      ri=bool, rm=bool, rr=bool, rp=bool, rt=bool, tb=bool,
-                                                      index=bool, middle=bool, ring=bool, pinky=bool, thumb=bool,
-                                                      lh=bool, rh=bool,
-                                                      name=list,
-                                                      )
+    kwargs: dict[str, str | bool]
+    kwargs, err = parser.get_kwargs(message, str,
+                                    li=bool, lm=bool, lr=bool, lp=bool, lt=bool,
+                                    ri=bool, rm=bool, rr=bool, rp=bool, rt=bool, tb=bool,
+                                    index=bool, middle=bool, ring=bool, pinky=bool, thumb=bool,
+                                    lh=bool, rh=bool,
+                                    name=list,
+                                    )
+    if err is not None:
+        return (f'{str(err)}\n'
+                f'```\n'
+                f'{use()}\n'
+                f'```')
+
     filter_name: str = "".join(kwargs['name'])
     sfb: str = kwargs['args']
     # No arguments
     if not sfb and not filter_name:
-        return '```\n' \
-               'search [sfb/column] [--fingers]\n' \
-               'Supported fingers: \n' \
-               'li, lm, lr, lp, ri, rm, rr, rp, lt, rt, tb, index, middle, ring, pinky, thumb, lh, rh, name\n' \
-               '```'
+        return f'```\n{use()}\n```'
+
     # Only filter by name
     if not sfb:
         res: list[str] = []
@@ -77,6 +81,7 @@ def exec(message: Message):
 
     return return_message(res, is_dm)
 
+
 def get_line_limit(res: list[str]) -> int:
     # Find the max number of lines that fit in the message (only for DMs)
     char_count = 0
@@ -87,6 +92,7 @@ def get_line_limit(res: list[str]) -> int:
             break
         line_limit += 1
     return line_limit
+
 
 def return_message(res: list[str], is_dm: bool) -> str:
     random.shuffle(res)
@@ -101,12 +107,15 @@ def return_message(res: list[str], is_dm: bool) -> str:
 
     return '\n'.join(lines)
 
+
 def is_similar(s1: str, s2: str) -> bool:
     return jw(s1, s2) > SIMILARITY_THRES
 
 
 def use():
-    return 'search [sfb/column] [--fingers | --name]'
+    return ('search [sfb/column] [--fingers] [--name <name>]\n'
+            'Supported fingers: \n'
+            'li, lm, lr, lp, ri, rm, rr, rp, lt, rt, tb, index, middle, ring, pinky, thumb, lh, rh, name\n')
 
 
 def desc():


### PR DESCRIPTION
- now strictly parse keyword arguments, any word starting with `--` that's not a valid keyword argument is no longer ignored and will return an error instead
- refactored `get_kwargs` and help messages in `filter`, `fspeed`, `mod`, `rank`, and `search`
- added help messages for `filter`